### PR TITLE
Fix binary operator expected warning

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -177,7 +177,7 @@ pre_commit_hook() {
     [ -n "$file" ] && files+=("$file")
   done <<< "$(git diff-index --diff-filter 'ACMU' --name-only --cached $rev --)"
   # when the file list empty, then don't all the scan, otherwise it will start scanning entire repo
-  [ -z "${files[@]}" ] && return
+  [[ -z "${files[@]}" ]] && return
   scan_with_fn_or_die "scan" "${files[@]}"
 }
 


### PR DESCRIPTION
*Issue #, if available:*
A warning message 
`...\.git-secrets\git-secrets: line 180: [: README.md: binary operator expected`

*Description of changes:*
The condition is updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
